### PR TITLE
Improve the visualizer a lot

### DIFF
--- a/packages/webamp-modern/src/skin/AudioPlayer.ts
+++ b/packages/webamp-modern/src/skin/AudioPlayer.ts
@@ -81,6 +81,8 @@ export class AudioPlayer {
     // this._analyser.fftSize = 512; //? to get same VIS to winamp osciloscpoe
     this._analyser.fftSize = 1024; //? exactly identical to winamp VIS. truncated later in VIS
     // don't smooth audio analysis
+    this._analyser.maxDecibels = -20;
+    this._analyser.minDecibels = -70;
     this._analyser.smoothingTimeConstant = 0.0;
 
     // default pan set to 0 - center

--- a/packages/webamp-modern/src/skin/AudioPlayer.ts
+++ b/packages/webamp-modern/src/skin/AudioPlayer.ts
@@ -81,8 +81,8 @@ export class AudioPlayer {
     // this._analyser.fftSize = 512; //? to get same VIS to winamp osciloscpoe
     this._analyser.fftSize = 1024; //? exactly identical to winamp VIS. truncated later in VIS
     // don't smooth audio analysis
-    this._analyser.maxDecibels = -20;
-    this._analyser.minDecibels = -70;
+    this._analyser.maxDecibels = -25;
+    this._analyser.minDecibels = -150;
     this._analyser.smoothingTimeConstant = 0.0;
 
     // default pan set to 0 - center

--- a/packages/webamp-modern/src/skin/makiClasses/Vis.ts
+++ b/packages/webamp-modern/src/skin/makiClasses/Vis.ts
@@ -827,6 +827,7 @@ class WavePaintHandler extends VisPaintHandler {
 
     if (bottom < top) {
       [bottom, top] = [top, bottom];
+      top++; //this emulates Winamp's/WACUP's OSC behavior correctly
     }
     // const h = bottom - top + 1;
 

--- a/packages/webamp-modern/src/skin/makiClasses/Vis.ts
+++ b/packages/webamp-modern/src/skin/makiClasses/Vis.ts
@@ -489,8 +489,8 @@ class BarPaintHandler extends VisPaintHandler {
         // j /* * xOffset */,
         x1,
         x2,
-        amplitude * heightMultiplier,
-        barPeak * heightMultiplier
+        Math.round(amplitude * heightMultiplier),
+        Math.round(barPeak * heightMultiplier)
       );
     }
   }
@@ -551,8 +551,8 @@ class BarPaintHandler extends VisPaintHandler {
         // j /* * xOffset */,
         j,
         j,
-        amplitude * heightMultiplier,
-        barPeak * heightMultiplier
+        Math.round(amplitude * heightMultiplier),
+        Math.round(barPeak * heightMultiplier)
       );
     }
   }

--- a/packages/webamp-modern/src/skin/makiClasses/Vis.ts
+++ b/packages/webamp-modern/src/skin/makiClasses/Vis.ts
@@ -178,7 +178,7 @@ export default class Vis extends GuiObj {
     this.audioStatusChanged();
     this._startVisualizer(); // visualizer always runs regardless of playback
   }
-
+//:)
   dispose() {
     super.dispose();
     this._stopVisualizer();
@@ -826,7 +826,7 @@ class WavePaintHandler extends VisPaintHandler {
     this._lastY = y;
 
     if (bottom < top) {
-      [bottom, top] = [top, y];
+      [bottom, top] = [top, bottom];
     }
     // const h = bottom - top + 1;
 

--- a/packages/webamp-modern/src/skin/makiClasses/Vis.ts
+++ b/packages/webamp-modern/src/skin/makiClasses/Vis.ts
@@ -117,7 +117,7 @@ export default class Vis extends GuiObj {
       case "colorband15":
       case "colorband16":
         // color spectrum band #
-        const cobaIndex = parseInt(key.substring(9)) - 1;
+        const cobaIndex = -(parseInt(key.substring(9)) - 1)+16; //sure... i'll take that fix
         this._colorBands[cobaIndex] = value;
         break;
       case "colorallbands":

--- a/packages/webamp-modern/src/skin/makiClasses/Vis.ts
+++ b/packages/webamp-modern/src/skin/makiClasses/Vis.ts
@@ -457,7 +457,7 @@ class BarPaintHandler extends VisPaintHandler {
       let weightingnum = 0;
       amplitude /= end - start;
       for (let i = start; i < end; i++) {
-        weightingnum = Math.max(weightingnum+3, this._dataArray2[i]); //see comments on paintFrameThin()
+        weightingnum = Math.max(weightingnum+2.5, this._dataArray2[i]); //see comments on paintFrameThin()
       }
       for (let k = start; k < end; k++) {
         amplitude = Math.max(amplitude, ((this._dataArray[k]*3.4)-600)+weightingnum); //see comments on paintFrameThin()
@@ -743,12 +743,12 @@ class WavePaintHandler extends VisPaintHandler {
     for (let j = 0; j <= width; j++) {
       // const amplitude = sliceAverage(this._dataArray, sliceWidth, j);
       const amplitude = slice1st(this._dataArray, sliceWidth, j);
-      const [y, colorIndex] = this.rangeByAmplitude(amplitude);
+      const [y, colorIndex] = this.rangeByAmplitude(amplitude*1.60-65);
       const x = j * PIXEL_DENSITY;
 
       this.paintWav(x, y, colorIndex);
     }
-
+//:)
     if (using16temporaryCanvas) {
       const canvas = this._vis._canvas
       const visCtx = canvas.getContext('2d');
@@ -826,7 +826,7 @@ class WavePaintHandler extends VisPaintHandler {
     this._lastY = y;
 
     if (bottom < top) {
-      [bottom, top] = [top, bottom];
+      [bottom, top] = [top, y];
     }
     // const h = bottom - top + 1;
 

--- a/packages/webamp-modern/src/skin/makiClasses/Vis.ts
+++ b/packages/webamp-modern/src/skin/makiClasses/Vis.ts
@@ -178,7 +178,7 @@ export default class Vis extends GuiObj {
     this.audioStatusChanged();
     this._startVisualizer(); // visualizer always runs regardless of playback
   }
-//:)
+
   dispose() {
     super.dispose();
     this._stopVisualizer();
@@ -743,12 +743,12 @@ class WavePaintHandler extends VisPaintHandler {
     for (let j = 0; j <= width; j++) {
       // const amplitude = sliceAverage(this._dataArray, sliceWidth, j);
       const amplitude = slice1st(this._dataArray, sliceWidth, j);
-      const [y, colorIndex] = this.rangeByAmplitude(amplitude*1.60-65);
+      const [y, colorIndex] = this.rangeByAmplitude(amplitude*1.60-75);
       const x = j * PIXEL_DENSITY;
 
       this.paintWav(x, y, colorIndex);
     }
-//:)
+
     if (using16temporaryCanvas) {
       const canvas = this._vis._canvas
       const visCtx = canvas.getContext('2d');

--- a/packages/webamp-modern/src/skin/makiClasses/Vis.ts
+++ b/packages/webamp-modern/src/skin/makiClasses/Vis.ts
@@ -176,6 +176,7 @@ export default class Vis extends GuiObj {
     this.setmode(this._mode); // in case xml doesn't define mode.
     super.init();
     this.audioStatusChanged();
+    this._startVisualizer(); // visualizer always runs regardless of playback
   }
 
   dispose() {
@@ -232,6 +233,7 @@ export default class Vis extends GuiObj {
     let newMode = this.getmode() + 1;
     if (newMode > 2) {
       newMode = 0;
+      this._setPainter(NoVisualizerHandler);
     }
     this.setmode(String(newMode));
   }
@@ -251,12 +253,13 @@ export default class Vis extends GuiObj {
   // disposable
   audioStatusChanged = () => {
     // to avoid multiple loop, we always stop the old painting loop
-    this._stopVisualizer();
+    //this._stopVisualizer();
+    // never stop the visualizer, the object continously runs regardless of playback
 
     // start the new loop
     const playing = this._uiRoot.audio.getState() == AUDIO_PLAYING;
     if (playing) {
-      this._startVisualizer();
+      //this._startVisualizer();
     }
   };
 
@@ -461,6 +464,9 @@ class BarPaintHandler extends VisPaintHandler {
         this._barPeakFrames[j] = 0;
       } else {
         this._barPeakFrames[j] += 1;
+      } if(barPeak < 10){
+        barPeak = 10;
+        this._barPeakFrames[j] = 0;
       }
       this._barPeaks[j] = barPeak;
 
@@ -511,6 +517,9 @@ class BarPaintHandler extends VisPaintHandler {
         this._barPeakFrames[j] = 0;
       } else {
         this._barPeakFrames[j] += 1;
+      } if(barPeak < 10){
+        barPeak = 10;
+        this._barPeakFrames[j] = 0;
       }
       this._barPeaks[j] = barPeak;
 


### PR DESCRIPTION
The Visualizer now runs all the time, though this comes with the side effect that, when no mode is selected, the last frame painted still exists.

This pull request also addresses the peaks disappearing into the bottom or the top if the audio is loud, which does not happen with the Modern Skin engine.

This also attempts to address the Spectrum Analyzer having a weird bias, whereas the top end of the audio (aka the highs) does not reach the top of the visualizer height, this approach can be improved on.

This also addresses the fact that the Spectrum Analyzers always looked blurry before the user switched to the Oscilloscope, which, after switching back to the Spectrum Analyzer, they'd look pixelated again. Commit b5b1cf4 makes them appear pixelated **all the time.**

This PR also addresses the fact that the Spectrum Analyzer color order was not in the right order.